### PR TITLE
saving pairs of towns and fields groups to a pmr vector

### DIFF
--- a/include/Carcassonne/Game/Game.h
+++ b/include/Carcassonne/Game/Game.h
@@ -7,10 +7,11 @@
 #include <mb/int.h>
 #include <memory>
 #include <random>
-#include <unordered_set>
+#include <memory_resource>
 
 namespace carcassonne::game {
 
+using Towns = std::vector<std::pair<Group, Group>, std::pmr::polymorphic_allocator<std::pair<Group, Group>>>;
 using EdgeGroups = Groups<g_edges_max>;
 
 class Game : public IGame {
@@ -19,6 +20,7 @@ class Game : public IGame {
    mb::u8 m_player_count = 2;
    std::vector<Figure> m_figures;
 
+   Towns m_towns;
    EdgeGroups m_groups;
    ScoreBoard m_scores;
 

--- a/include/Carcassonne/Groups.h
+++ b/include/Carcassonne/Groups.h
@@ -14,7 +14,7 @@ constexpr mb::size g_empty = std::numeric_limits<mb::size>::max();
 template<mb::size S>
 class Groups {
    std::array<Group, S> m_group{};
-   std::array<mb::size, S> m_backtrack{};
+   std::array<Group, S> m_backtrack{};
    std::array<PlayerAssignment, S> m_assignments{};
    std::array<EdgeType, S> m_types{};
    std::array<mb::u8, S> m_free_edges{};

--- a/src/Carcassonne/Game/Game.cpp
+++ b/src/Carcassonne/Game/Game.cpp
@@ -52,7 +52,7 @@ void Game::apply_tile(int x, int y, TileType tt, mb::u8 rot) noexcept {
       Group field_group{m_groups.group_of(make_edge(x, y, b))};
       auto is_pair_found = [town_group, field_group](std::pair<Group, Group> town_field) {
          return town_group == town_field.first && field_group == town_field.second;};
-      if (auto result = std::ranges::find_if(m_towns.begin(), m_towns.end(), is_pair_found); result == m_towns.end())
+      if (auto result = std::find_if(m_towns.begin(), m_towns.end(), is_pair_found); result == m_towns.end())
          m_towns.push_back(std::make_pair(town_group, field_group));
    }
    mb::u8 buffer[sizeof(Group) * 8];

--- a/src/Carcassonne/Game/Game.cpp
+++ b/src/Carcassonne/Game/Game.cpp
@@ -2,12 +2,11 @@
 #include <Carcassonne/Game/Move.h>
 #include <algorithm>
 #include <fmt/core.h>
-#include <memory_resource>
 #include <set>
 
 namespace carcassonne::game {
 
-Game::Game() : m_random_generator(10101) {
+Game::Game() : m_random_generator(6) {
    apply_tile(70, 70, 1, 3);
 }
 
@@ -31,9 +30,9 @@ void Game::add_figure(Figure f) {
    m_figures.push_back(f);
 }
 
-std::unique_ptr<IMove> Game::new_debug_move(Player p, TileType tt) noexcept {
-   return std::make_unique<Move>(p, tt, *this);
-}
+// std::unique_ptr<IMove> Game::new_debug_move(Player p, TileType tt) noexcept {
+//    return std::make_unique<Move>(p, tt, *this);
+// } // it it necessary?
 
 void Game::apply_tile(int x, int y, TileType tt, mb::u8 rot) noexcept {
    m_board.set_tile(x, y, tt, rot);
@@ -42,8 +41,19 @@ void Game::apply_tile(int x, int y, TileType tt, mb::u8 rot) noexcept {
    auto connections = tile.connections;
    while (connections != Connection::None) {
       Direction a, b;
-      std::tie(connections, a, b) = read_directions(connections);
+      std::tie(connections, a, b) = read_connections(connections);
       m_groups.join(make_edge(x, y, a), make_edge(x, y, b));
+   }
+   auto contacts = tile.contacts;
+   while (contacts != Contact::None) {
+      Direction a, b;
+      std::tie(contacts, a, b) = read_contacts(contacts);
+      Group town_group{m_groups.group_of(make_edge(x, y, a))};
+      Group field_group{m_groups.group_of(make_edge(x, y, b))};
+      auto is_pair_found = [town_group, field_group](std::pair<Group, Group> town_field) {
+         return town_group == town_field.first && field_group == town_field.second;};
+      if (auto result = std::ranges::find_if(m_towns.begin(), m_towns.end(), is_pair_found); result == m_towns.end())
+         m_towns.push_back(std::make_pair(town_group, field_group));
    }
    mb::u8 buffer[sizeof(Group) * 8];
    std::pmr::monotonic_buffer_resource pool(std::data(buffer), std::size(buffer));


### PR DESCRIPTION
Ze względu na przechodzenie całego wektora par przy każdym położeniu kafelka w poszukiwaniu, czy nie ma już w nim tej pary miasto-pole, która ma zostać w nim umieszczona użyłem pmr. 

Turner twierdzi, że wektor przeszukuje się szybciej z prm'em 😃 